### PR TITLE
fix(SAEPB0199 Ajustes): 25SAEPB0199M004005 Ajustes incapacidades

### DIFF
--- a/components/employeeCalendarShiftDayControl/index.vue
+++ b/components/employeeCalendarShiftDayControl/index.vue
@@ -11,7 +11,7 @@
     <div class="shift">
       <Dropdown v-if="drawerEmployeeShiftForm && employeeShift && shiftEditSelected && (shiftEditSelected.day === employeeCalendar.day)" v-model="employeeShift.shiftId" :options="shiftsList" optionLabel="shiftName" optionValue="shiftId" filter />
       <div v-else>
-        <span v-if="!employeeCalendar.assist.dateShift || employeeCalendar.assist.isRestDay || employeeCalendar.assist.isVacationDate" class="off">
+        <span v-if="!employeeCalendar.assist.dateShift || employeeCalendar.assist.isRestDay || employeeCalendar.assist.isVacationDate || employeeCalendar.assist.isWorkDisabilityDate" class="off">
           ---- -- ----
         </span>
         <span v-else :class="{ off: employeeCalendar.assist.isHoliday }">
@@ -28,6 +28,9 @@
       </span>
       <span v-else-if="employeeCalendar.assist.dateShift && employeeCalendar.assist.isVacationDate">
         Vacation day
+      </span>
+      <span v-else-if="employeeCalendar.assist.dateShift && employeeCalendar.assist.isWorkDisabilityDate">
+        Work disability day
       </span>
       <span v-else-if="employeeCalendar.assist.isHoliday && employeeCalendar.assist.holiday">
         {{ employeeCalendar.assist.holiday.holidayName }}

--- a/components/employeeExceptionRequestInfoForm/script.ts
+++ b/components/employeeExceptionRequestInfoForm/script.ts
@@ -115,6 +115,12 @@ export default defineComponent({
     hasAccess = await myGeneralStore.hasAccess(systemModuleSlug, 'add-exception')
     const exceptionType = hasAccess ? '' : 'rest-day'
     this.exceptionTypeList = await this.getExceptionTypes(exceptionType, true)
+    const existRestDayIndex = this.exceptionTypeList.findIndex(a => a.exceptionTypeSlug === 'falta-por-incapacidad')
+    if (existRestDayIndex >= 0) {
+      if (this.exceptionTypeList[existRestDayIndex].exceptionTypeId !== this.exceptionRequest.exceptionTypeId) {
+        this.exceptionTypeList.splice(existRestDayIndex, 1)
+      }
+    }
     if (this.exceptionRequest.exceptionRequestId) {
       let existCurrentExceptionType = this.exceptionTypeList.find(a => a.exceptionTypeId === this.exceptionRequest.exceptionTypeId)
       if (!existCurrentExceptionType) {

--- a/components/employeeShift/index.vue
+++ b/components/employeeShift/index.vue
@@ -133,22 +133,23 @@
     </Sidebar>
 
     <Sidebar
-      v-model:visible="displaySidebarWorkDisabilities"
-      :blockScroll="true"
-      :dismissable="false"
-      :closeOnEscape="false"
-      header="work disabilities"
-      position="right"
-      class="work-disabilities-sidebar"
-      >
-      <employeeWorkDisabilities
-        :employee="employee"
-        :status-form="statusForm"
-        :can-manage-work-disability="canManageWorkDisability"
-        :canManageException="canManageShiftOrException"
-        @save="onSave"
-      />
-    </Sidebar>
+    v-model:visible="displaySidebarWorkDisabilities"
+    :blockScroll="true"
+    :dismissable="false"
+    :closeOnEscape="false"
+    header="work disabilities"
+    position="right"
+    class="work-disabilities-sidebar"
+    >
+    <employeeWorkDisabilities
+      :employee="employee"
+      :status-form="statusForm"
+      :can-manage-work-disability="canManageWorkDisability"
+      :canManageException="canManageShiftOrException"
+      @save="onSave"
+    />
+  </Sidebar>
+    
   </div>
   <div v-else class="loader">
     <ProgressSpinner />

--- a/components/employeeShiftException/script.ts
+++ b/components/employeeShiftException/script.ts
@@ -121,16 +121,17 @@ export default defineComponent({
       const shiftExceptionService = new ShiftExceptionService()
       const shiftExceptionResponse = await shiftExceptionService.getByEmployee(employeeId, this.selectedExceptionTypeId, this.selectedDateStart, this.selectedDateEnd)
       this.shiftExceptionsList = shiftExceptionResponse
-      const exceptionTypeVacationId = await this.getExceptionTypeVacation()
+      const exceptionTypeVacationId = await this.getExceptionTypeBySlug('vacation')
+      const exceptionTypeWorkDisabilityId = await this.getExceptionTypeBySlug('falta-por-incapacidad')
       if (exceptionTypeVacationId) {
-        this.shiftExceptionsList = this.shiftExceptionsList.filter(a => a.exceptionTypeId !== exceptionTypeVacationId)
+        this.shiftExceptionsList = this.shiftExceptionsList.filter(a => a.exceptionTypeId !== exceptionTypeVacationId && a.exceptionTypeId !== exceptionTypeWorkDisabilityId)
       }
       myGeneralStore.setFullLoader(false)
     },
-    async getExceptionTypeVacation() {
+    async getExceptionTypeBySlug(type: string) {
       const response = await new ExceptionTypeService().getFilteredList('', 1, 100)
       const list: ExceptionTypeInterface[] = response.status === 200 ? response._data.data.exceptionTypes.data : []
-      const exceptionTypeList = list.filter(item => item.exceptionTypeSlug === 'vacation')
+      const exceptionTypeList = list.filter(item => item.exceptionTypeSlug === type)
       return exceptionTypeList.length > 0 ? exceptionTypeList[0].exceptionTypeId : null
     },
     addNew() {

--- a/components/employeeShiftExceptionInfoForm/script.ts
+++ b/components/employeeShiftExceptionInfoForm/script.ts
@@ -80,7 +80,7 @@ export default defineComponent({
       } else {
         this.shiftException.shiftExceptionEnjoymentOfSalary = null
       }
-     
+
     }
   },
   async mounted() {
@@ -125,6 +125,12 @@ export default defineComponent({
         }
       }
     }
+    const existRestDayIndex = this.exceptionTypeList.findIndex(a => a.exceptionTypeSlug === 'falta-por-incapacidad')
+    if (existRestDayIndex >= 0) {
+      if (this.exceptionTypeList[existRestDayIndex].exceptionTypeId !== this.shiftException.exceptionTypeId) {
+        this.exceptionTypeList.splice(existRestDayIndex, 1)
+      }
+    }
     if (this.shiftException.shiftExceptionId) {
       let existCurrentExceptionType = this.exceptionTypeList.find(a => a.exceptionTypeId === this.shiftException.exceptionTypeId)
       if (!existCurrentExceptionType) {
@@ -135,7 +141,7 @@ export default defineComponent({
         }
       }
     }
-   
+
 
     let isVacation = false
     const index = this.exceptionTypeList.findIndex(opt => opt.exceptionTypeId === this.shiftException.exceptionTypeId)
@@ -261,7 +267,7 @@ export default defineComponent({
         }
       }
       this.shiftException.shiftExceptionTimeByTime = this.activeSwichtTimeByTime ? 1 : 0
-      if ( this.shiftException.shiftExceptionTimeByTime === 1) {
+      if (this.shiftException.shiftExceptionTimeByTime === 1) {
         this.shiftException.shiftExceptionEnjoymentOfSalary = 0
       }
       if (!this.needPeriodDays) {
@@ -382,7 +388,7 @@ export default defineComponent({
           this.applyToMoreThanOneDay = false
           this.shiftException.daysToApply = 0
         }
-        
+
         this.setMinDate(isVacation)
       }
     },

--- a/components/employeeWorkDisabilities/index.vue
+++ b/components/employeeWorkDisabilities/index.vue
@@ -26,7 +26,7 @@
       <Sidebar v-model:visible="drawerWorkDisabilityForm" header="form" position="right"
       class="work-disability-form-sidebar" :showCloseIcon="true">
       <employeeWorkDisabilityInfoForm :canManageWorkDisability="canManageWorkDisability"
-        :workDisability="workDisability" :employee="employee" @save="onSave" />
+        :workDisability="workDisability" :employee="employee" @onWorkDisabilitySave="onSave" @save="onSave" />
     </Sidebar>
     </div>
     <ProgressSpinner v-else />

--- a/components/employeeWorkDisabilities/script.ts
+++ b/components/employeeWorkDisabilities/script.ts
@@ -35,9 +35,17 @@ export default defineComponent({
   },
   async mounted() {
     this.isReady = false
-    this.getWorkDisabilities()
+    await this.getWorkDisabilities()
     if (this.employee.deletedAt) {
       this.isDeleted = true
+    }
+    const myGeneralStore = useMyGeneralStore()
+    if (myGeneralStore.workDisabilityId) {
+     const existWorkDisability = this.workDisabilities.find(a => a.workDisabilityId === myGeneralStore.workDisabilityId)
+     if (existWorkDisability) {
+      this.workDisability = existWorkDisability
+      this.drawerWorkDisabilityForm = true
+     }
     }
     this.isReady = true
   },

--- a/components/employeeWorkDisabilityInfoForm/index.vue
+++ b/components/employeeWorkDisabilityInfoForm/index.vue
@@ -15,7 +15,7 @@
           <label for="uuid">
             UUID
           </label>
-          <InputText v-model="workDisability.workDisabilityUuid" disabled />
+          {{ workDisability.workDisabilityUuid.toLocaleUpperCase() }}
         </div>
         <div class="input-box">
           <label for="exception-type">
@@ -23,7 +23,7 @@
           </label>
           <Dropdown v-model="workDisability.insuranceCoverageTypeId" :options="insuranceCoverageTypeList"
             optionLabel="insuranceCoverageTypeName" optionValue="insuranceCoverageTypeId" placeholder="" filter
-            class="w-full md:w-14rem" disabled/>
+            class="w-full md:w-14rem" :disabled="!isNewWorkDisability"/>
           <small class="p-error" v-if="submitted && !workDisability.insuranceCoverageTypeId">Insurance coverage type is
             required.</small>
         </div>
@@ -92,6 +92,14 @@
   @import '/resources/styles/variables.scss';
 
   .work-disability-period-form-sidebar {
+    width: 100% !important;
+    max-width: 33rem !important;
+
+    @media screen and (max-width: $sm) {
+      width: 100% !important;
+    }
+  }
+  .work-disability-note-form-sidebar {
     width: 100% !important;
     max-width: 33rem !important;
 

--- a/components/employeeWorkDisabilityInfoForm/script.ts
+++ b/components/employeeWorkDisabilityInfoForm/script.ts
@@ -110,7 +110,7 @@ export default defineComponent({
         workDisabilityResponse = await workDisabilityService.show(workDisabilityResponse._data.data.workDisability.workDisabilityId)
         if (workDisabilityResponse.status === 200) {
           const workDisability = workDisabilityResponse._data.data.workDisability
-          this.$emit('onWorkDisabilitySave', workDisability as WorkDisabilityInterface)
+          this.$emit('onWorkDisabilitySave', workDisability as WorkDisabilityInterface, [])
         }
       } else {
         const msgError = workDisabilityResponse._data.error ? workDisabilityResponse._data.error : workDisabilityResponse._data.message
@@ -137,6 +137,7 @@ export default defineComponent({
       this.isReady = false
       const myGeneralStore = useMyGeneralStore()
       myGeneralStore.setFullLoader(true)
+      myGeneralStore.workDisabilityId = workDisabilityPeriod.workDisabilityId
       this.workDisabilityPeriod = { ...workDisabilityPeriod }
       const index = this.workDisabilityPeriodsList.findIndex((workDisabilityPeriod: WorkDisabilityPeriodInterface) => workDisabilityPeriod.workDisabilityPeriodId === this.workDisabilityPeriod?.workDisabilityPeriodId)
       if (index !== -1) {

--- a/components/employeeWorkDisabilityPeriodInfoForm/index.vue
+++ b/components/employeeWorkDisabilityPeriodInfoForm/index.vue
@@ -78,7 +78,7 @@
             placeholder="Select date range"
             class="w-full md:w-14rem" 
           />
-          <small class="p-error" v-if="submitted && (!dates || dates.length !== 2)">
+          <small class="p-error" v-if="submitted && (!workDisabilityPeriod.workDisabilityPeriodStartDate || !workDisabilityPeriod.workDisabilityPeriodEndDate)">
           Dates are required.
           </small>
         </div>

--- a/components/workDisabilityInfoCard/index.vue
+++ b/components/workDisabilityInfoCard/index.vue
@@ -12,11 +12,6 @@
           {{ workDisability.insuranceCoverageType.insuranceCoverageTypeName }} 
           </div>
       </div>
-      <div class="uuid">
-        <div v-if="workDisability.workDisabilityUuid">
-          {{ workDisability.workDisabilityUuid }}
-        </div>
-      </div>
     </div>
 
     <div v-if="!isDeleted" class="box-tools-footer">

--- a/resources/scripts/interfaces/AssistDayInterface.ts
+++ b/resources/scripts/interfaces/AssistDayInterface.ts
@@ -18,6 +18,7 @@ interface AssistDayInterface {
     isSundayBonus: boolean
     isRestDay: boolean
     isVacationDate: boolean
+    isWorkDisabilityDate: boolean
     isHoliday: boolean
     checkInDateTime: Date | string
     checkOutDateTime: Date | string

--- a/store/general.ts
+++ b/store/general.ts
@@ -20,7 +20,8 @@ export const useMyGeneralStore = defineStore({
     displayContent: false,
     userVacationFormClosed: false,
     systemSettingId: null as number | null,
-    systemModules: [] as Array<SystemModuleInterface>
+    systemModules: [] as Array<SystemModuleInterface>,
+    workDisabilityId: null as number | null,
   }),
   actions: {
     setDisplayAside(status: boolean) {


### PR DESCRIPTION
En el modulo de empleados en el apartado de incapacidades se quito el uuid de la incapacidad de la tarjeta y en el formulario se puso con mayusculas, en los formularios de excepciones de turno y solicito de excepciones se quito el tipo de excepción ‘falta por incapacidad’ , se le dio la misma funcionalidad a este tipo que las vacaciones (que no se vea el botón en verde y que no se muestre en las excepciones del dic seleccionado), se soluciono el cierre del Sidecar de incapacidad al guardar un periodo