### PR TITLE
feat(employees): add conditional display for responsible section button

### DIFF
--- a/pages/employees/index.vue
+++ b/pages/employees/index.vue
@@ -138,7 +138,7 @@
               </svg>
               Work
             </Button>
-            <Button :class="{ 'btn-active': isActive('responsible') }" class="btn" @click="onEditResponsible">
+            <Button v-if="displayResponsibleSection" :class="{ 'btn-active': isActive('responsible') }" class="btn" @click="onEditResponsible">
               <svg fill="none" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
                 <path
                   d="M10.968 2.325a1.75 1.75 0 0 1 2.064 0l7.421 5.416c.977.712.474 2.257-.734 2.26H4.28c-1.208-.003-1.71-1.548-.734-2.26l7.421-5.416ZM13 6.25a1 1 0 1 0-2 0 1 1 0 0 0 2 0ZM11.25 16h-2v-5h2v5ZM14.75 16h-2v-5h2v5ZM18.5 16h-2.25v-5h2.25v5ZM18.75 17H5.25A2.25 2.25 0 0 0 3 19.25v.5c0 .415.336.75.75.75h16.5a.75.75 0 0 0 .75-.75v-.5A2.25 2.25 0 0 0 18.75 17ZM7.75 16H5.5v-5h2.25v5Z"

--- a/pages/employees/script.ts
+++ b/pages/employees/script.ts
@@ -76,6 +76,13 @@ export default defineComponent({
       }
 
       return display
+    },
+    displayResponsibleSection () {
+      if (this.isRootUser) {
+        return true
+      }
+
+      return false
     }
   },
   created() { },


### PR DESCRIPTION
Introduced a new computed property to control the visibility of the responsible section button based on user permissions. The button is now only displayed for root users, enhancing the user interface by streamlining access to responsible user editing.